### PR TITLE
Backward compatibility if `User.find_by_credentials` doesn't exist

### DIFF
--- a/frappe_telegram/handlers/login.py
+++ b/frappe_telegram/handlers/login.py
@@ -70,7 +70,6 @@ def collect_email_and_ask_for_pwd(update: Update, context: CallbackContext):
         update.message.reply_text("You have entered invalid credentials. Please try again")
         return ask_email(update, context)
 
-@frappe.whitelist(allow_guest=True)
 def verify_credentials(email, pwd):
     from frappe.core.doctype.user.user import User
 

--- a/frappe_telegram/handlers/login.py
+++ b/frappe_telegram/handlers/login.py
@@ -70,6 +70,7 @@ def collect_email_and_ask_for_pwd(update: Update, context: CallbackContext):
         update.message.reply_text("You have entered invalid credentials. Please try again")
         return ask_email(update, context)
 
+
 def verify_credentials(email, pwd):
     from frappe.core.doctype.user.user import User
 
@@ -77,7 +78,6 @@ def verify_credentials(email, pwd):
         user = User.find_by_credentials(email, pwd)
         return user        
     except AttributeError:
-        
         users = frappe.db.get_all('User', fields=['name', 'enabled'], or_filters=[{"name":email}], limit=1)
         if not users:
             return

--- a/frappe_telegram/handlers/login.py
+++ b/frappe_telegram/handlers/login.py
@@ -85,7 +85,7 @@ def verify_credentials(email, pwd):
         user = users[0]
         user['is_authenticated'] = True
         try:
-            check_password(user['name'], pwd, delete_tracker_cache=False)
+            check_password(user['name'], pwd)
         except frappe.AuthenticationError:
             user['is_authenticated'] = False
 


### PR DESCRIPTION
Fixes for making `frappe_telegram` backwards compatible with `frappe` prior to introducing `User.find_by_credentials`