### PR TITLE
feat: Telegram Message Template

### DIFF
--- a/frappe_telegram/client.py
+++ b/frappe_telegram/client.py
@@ -1,5 +1,8 @@
 import frappe
+from frappe import _
+from frappe.utils.jinja import render_template
 from frappe_telegram import Bot, ParseMode
+from frappe_telegram.frappe_telegram.doctype.telegram_bot import DEFAULT_TELEGRAM_BOT_KEY
 from frappe_telegram.handlers.logging import log_outgoing_message
 
 
@@ -11,14 +14,20 @@ bot interactions via Hooks / Controller methods
 
 
 def send_message(message_text: str, parse_mode=None, user=None, telegram_user=None, from_bot=None):
-    '''
+    """
     Send a message using a bot to a Telegram User
 
     message_text: `str`
         A text string between 0 and 4096 characters that will be the message
     parse_mode: `ParseMode`
         Choose styling for your message using a ParseMode class constant. Default is `None`
-    '''
+    user: `str`
+        Can optionally be used to reslove `telegram_user` using a User linked to a Telegram User
+    telegram_user: `str`
+        Selects the Telegram User to send the message to. Can be skipped if `user` is set
+    from_bot: `str`
+        Explicitly specify a bot name to send message from; the default is used if none specified
+    """
 
     if parse_mode:
         if parse_mode not in \
@@ -27,7 +36,7 @@ def send_message(message_text: str, parse_mode=None, user=None, telegram_user=No
 
     telegram_user_id = get_telegram_user_id(user=user, telegram_user=telegram_user)
     if not from_bot:
-        from_bot = frappe.get_value("Telegram Bot", {})
+        from_bot = frappe.db.get_default(DEFAULT_TELEGRAM_BOT_KEY)
 
     bot = get_bot(from_bot)
     message = bot.send_message(telegram_user_id, text=message_text, parse_mode=parse_mode)
@@ -35,7 +44,7 @@ def send_message(message_text: str, parse_mode=None, user=None, telegram_user=No
 
 
 def send_file(file, filename=None, message=None, user=None, telegram_user=None, from_bot=None):
-    '''
+    """
     Send a file to the bot
 
     file: (`str` | `filelike object` | `bytes` | `pathlib.Path` | `telegram.Document`)
@@ -44,7 +53,7 @@ def send_file(file, filename=None, message=None, user=None, telegram_user=None, 
         Specify custom file name
     message: `str`
         Small text to show alongside the file. 0-1024 characters
-    '''
+    """
 
     telegram_user_id = get_telegram_user_id(
         user=user, telegram_user=telegram_user)
@@ -80,3 +89,48 @@ def get_bot(telegram_bot) -> Bot:
     return ExtBot(
         token=telegram_bot.get_password("api_token")
     )
+
+
+def send_message_from_template(template: str, context: dict = {}, lang: str = None,
+                               parse_mode=None, user=None, telegram_user=None, from_bot=None):
+    """
+    Use a Telegram Message Template to send a message
+
+    template: `str`
+        Name of a Telegram Message Template
+    context: `dict`
+        dict of key:values to reslove the tags in the template
+    lang: `str`
+        Optionally can be set if an alternative template language is needed
+    """
+
+    dt = "Telegram Message Template"
+
+    filters = [
+        ["name", "=", template],
+    ]
+    if lang:
+        filters.append(["Telegram Message Template Translation", "language", "=", lang])
+
+    templates = frappe.get_all(
+        dt,
+        filters=filters
+    )
+
+    if not templates:
+        if lang:
+            frappe.throw(_("No template with name '{0}' and language '{1}' exists.").format(
+                template, lang))
+        else:
+            frappe.throw(_("No template with name '{0}' exists.").format(template))
+
+    template_doc = frappe.get_doc(dt, templates[0].name)
+
+    if lang:
+        for translation in template_doc.template_translations:
+            if translation.language == lang:
+                template = translation.template
+    else:
+        template = template_doc.default_template
+
+    send_message(render_template(template, context), parse_mode, user, telegram_user, from_bot)

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.js
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Leam Technology Systems and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Telegram Message Template', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.json
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.json
@@ -1,0 +1,73 @@
+{
+ "actions": [],
+ "autoname": "field:template_name",
+ "creation": "2021-11-15 21:02:22.949987",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "template_name",
+  "default_template",
+  "translations_section",
+  "template_translations"
+ ],
+ "fields": [
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "template_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Template Name",
+   "reqd": 1,
+   "set_only_once": 1,
+   "unique": 1
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "description": "Use Jinja tags to represent dynamic fields, like so: {{variable}}",
+   "fieldname": "default_template",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Default Template",
+   "reqd": 1
+  },
+  {
+   "fieldname": "translations_section",
+   "fieldtype": "Section Break",
+   "label": "Translation"
+  },
+  {
+   "description": "By specifying the Language, an alternative to the Default Template can be used",
+   "fieldname": "template_translations",
+   "fieldtype": "Table",
+   "label": "Template Translations",
+   "options": "Telegram Message Template Translation"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-11-15 21:33:46.066390",
+ "modified_by": "Administrator",
+ "module": "Frappe Telegram",
+ "name": "Telegram Message Template",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "search_fields": "template_name",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template/telegram_message_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, Leam Technology Systems and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TelegramMessageTemplate(Document):
+    pass

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template/test_telegram_message_template.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template/test_telegram_message_template.py
@@ -37,7 +37,7 @@ class TelegramMessageTemplateFixtures(TestFixture):
             default_template="This is a test template {{test}}",
             template_translations=[
                 frappe._dict(
-                    language="test_l",
+                    language="ja",
                     template='This is the translation {{test}}'
                 )
             ]
@@ -68,16 +68,16 @@ class TestTelegramMessageTemplate(unittest.TestCase):
         with self.assertRaises(ValidationError):
             send_message_from_template("randomTemplateDNE", lang="randonlang")
 
-        # Send a message with right name + non existing lang
-        with self.assertRaises(ValidationError):
-            send_message_from_template(
-                templates[1].name,
-                {"test": "like this"},
-                lang="randomlang"
-            )
-
         # TODO: How to set up a Telegram User?
         # TODO: How to send messages and confirm their output?
+
+        # # Send a message with right name + non existing lang
+        # with self.assertRaises(ValidationError):
+        #     send_message_from_template(
+        #         templates[1].name,
+        #         {"test": "like this"},
+        #         lang="randomlang"
+        #     )
 
         # # Send a message with right name
         # send_message_from_template(

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template/test_telegram_message_template.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template/test_telegram_message_template.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2021, Leam Technology Systems and Contributors
+# See license.txt
+
+import unittest
+from re import template
+
+import frappe
+from frappe.exceptions import ValidationError
+from frappe_telegram.client import send_message_from_template
+from frappe_telegram.frappe_telegram.doctype.telegram_user.test_telegram_user import \
+    TelegramUserFixtures
+from frappe_telegram.utils.test_fixture import TestFixture
+
+
+class TelegramMessageTemplateFixtures(TestFixture):
+
+    def __init__(self):
+        super().__init__()
+
+        self.DEFAULT_DOCTYPE = "Telegram Message Template"
+        self.dependent_fixtures = [
+            TelegramUserFixtures
+        ]
+
+    def make_fixtures(self):
+
+        fix_1 = frappe.get_doc(frappe._dict(
+            doctype=self.DEFAULT_DOCTYPE,
+            template_name="Test Template 1",
+            default_template="This is a test template {{test}}"
+        )).insert()
+        self.add_document(fix_1)
+
+        fix_2 = frappe.get_doc(frappe._dict(
+            doctype=self.DEFAULT_DOCTYPE,
+            template_name="Test Template 2",
+            default_template="This is a test template {{test}}",
+            template_translations=[
+                frappe._dict(
+                    language="test_l",
+                    template='This is the translation {{test}}'
+                )
+            ]
+        )).insert()
+        self.add_document(fix_2)
+
+
+class TestTelegramMessageTemplate(unittest.TestCase):
+
+    templates = TelegramMessageTemplateFixtures()
+
+    def setUp(self) -> None:
+        self.templates.setUp()
+
+    def tearDown(self) -> None:
+        self.templates.tearDown()
+
+    def test_send_message_from_template(self):
+        "Test the send_message_from_template client method"
+
+        templates = self.templates.fixtures.get("Telegram Message Template")
+
+        # Send a message with wrong template name
+        with self.assertRaises(ValidationError):
+            send_message_from_template("randomTemplateDNE")
+
+        # Send a message with wrong template name + non existing lang
+        with self.assertRaises(ValidationError):
+            send_message_from_template("randomTemplateDNE", lang="randonlang")
+
+        # Send a message with right name + non existing lang
+        with self.assertRaises(ValidationError):
+            send_message_from_template(
+                templates[1].name,
+                {"test": "like this"},
+                lang="randomlang"
+            )
+
+        # TODO: How to set up a Telegram User?
+        # TODO: How to send messages and confirm their output?
+
+        # # Send a message with right name
+        # send_message_from_template(
+        #     templates[0].name,
+        #     {"test": "like this"},
+        #     telegram_user=self.templates.get_dependencies("Telegram User")[0].name
+        # )
+
+        # # Send a message with right name + existing lang
+        # send_message_from_template(
+        #     templates[1].name,
+        #     {"test": "like this"},
+        #     templates[1].template_translations[0].language,
+        #     telegram_user=self.templates.get_dependencies("Telegram User")[0].name
+        # )

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.json
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.json
@@ -12,11 +12,11 @@
  "fields": [
   {
    "fieldname": "language",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Language",
-   "reqd": 1,
-   "unique": 1
+   "options": "Language",
+   "reqd": 1
   },
   {
    "description": "Use Jinja tags to represent dynamic fields, like so: {{variable}}",
@@ -29,7 +29,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-11-16 09:49:23.092906",
+ "modified": "2021-11-22 10:41:03.354394",
  "modified_by": "Administrator",
  "module": "Frappe Telegram",
  "name": "Telegram Message Template Translation",

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.json
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2021-11-15 20:47:24.219471",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "language",
+  "template"
+ ],
+ "fields": [
+  {
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Language",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "Use Jinja tags to represent dynamic fields, like so: {{variable}}",
+   "fieldname": "template",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Template"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2021-11-16 09:49:23.092906",
+ "modified_by": "Administrator",
+ "module": "Frappe Telegram",
+ "name": "Telegram Message Template Translation",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message_template_translation/telegram_message_template_translation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, Leam Technology Systems and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TelegramMessageTemplateTranslation(Document):
+    pass

--- a/frappe_telegram/frappe_telegram/doctype/telegram_user/test_telegram_user.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_user/test_telegram_user.py
@@ -1,8 +1,33 @@
 # Copyright (c) 2021, Leam Technology Systems and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 import unittest
 
+from frappe_telegram.utils.test_fixture import TestFixture
+
+
+class TelegramUserFixtures(TestFixture):
+
+    def __init__(self):
+        super().__init__()
+        self.DEFAULT_DOCTYPE = "Telegram User"
+
+    def make_fixtures(self):
+
+        # TODO: How to make telegram user for testing? Mock values won't work
+
+        # fix_1 = frappe.get_doc(
+        #     doctype="Telegram User",
+        #     telegram_user_id="10101010101010",
+        #     telegram_username="@testfixfullname",
+        #     full_name="test_fix_fullname"
+        # ).insert(ignore_permissions=True)
+        # frappe.db.commit()
+        # self.add_document(fix_1)
+
+        pass
+
+
 class TestTelegramUser(unittest.TestCase):
-	pass
+    pass


### PR DESCRIPTION
This PR adds:
1. A new Doctype, Telegram Message Template. Using this, Templates can be defined to easily send messages like notifications through the use of Jinja tags. It also supports multi-language support.
2. Adds the `send_message_from_template` to use these templates to send messages.

Also introduces a fix, some addition to documentation and a test for the new doc-type.