### PR TITLE
fix: ParseMode HTML for messages from FrappeNotification

### DIFF
--- a/frappe_telegram/client.py
+++ b/frappe_telegram/client.py
@@ -2,6 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils.jinja import render_template
 from frappe_telegram import Bot, ParseMode
+from frappe_telegram.utils.formatting import strip_unsupported_html_tags
 from frappe_telegram.frappe_telegram.doctype.telegram_bot import DEFAULT_TELEGRAM_BOT_KEY
 from frappe_telegram.handlers.logging import log_outgoing_message
 
@@ -31,6 +32,10 @@ def send_message(message_text: str, parse_mode=None, user=None, telegram_user=No
     if parse_mode and parse_mode not in [value for name, value in vars(ParseMode).items() if
                                          not name.startswith('_')]:
         raise ValueError("Please use a valid ParseMode constant.")
+
+    if parse_mode == ParseMode.HTML:
+        # Telegram API throws error if not formatted properly
+        message_text = strip_unsupported_html_tags(message_text)
 
     telegram_user_id = get_telegram_user_id(user=user, telegram_user=telegram_user)
     if not from_bot:

--- a/frappe_telegram/override_doctype_class/notification.py
+++ b/frappe_telegram/override_doctype_class/notification.py
@@ -46,12 +46,16 @@ def send_telegram_notification(notification, doc):
         from_bot = frappe.db.get_default(DEFAULT_TELEGRAM_BOT_KEY)
 
     for user in users:
+        if not frappe.db.exists("Telegram User", {"user": user}):
+            continue
+
         frappe.enqueue(
             method=send_message,
             queue="short",
             message_text=message_text,
             user=user,
             from_bot=from_bot,
+            parse_mode="HTML",
             enqueue_after_commit=True
         )
 

--- a/frappe_telegram/utils/formatting.py
+++ b/frappe_telegram/utils/formatting.py
@@ -1,0 +1,53 @@
+import re
+
+
+def strip_unsupported_html_tags(txt: str) -> str:
+    """
+    Only a set of formatting options are supported
+    https://core.telegram.org/bots/api#formatting-options
+    """
+    tags_supported = [
+        "b", "strong",              # Bold
+        "i", "em",                  # Italics
+        "u", "ins",                 # Underline
+        "s", "strike", "del",       # Strikethrough
+        "a",                        # Links
+        "pre", "code",              # Code
+    ]
+
+    # Replace Unsupported Tags
+    """
+    < /?                    # Permit closing tags
+    (?!
+        (?: em | strong )   # List of tags to avoid matching
+        \b                  # Word boundary avoids partial word matches
+    )
+    [a-z]                   # Tag name initial character must be a-z
+    (?: [^>"']              # Any character except >, ", or '
+    | "[^"]*"               # Double-quoted attribute value
+    | '[^']*'               # Single-quoted attribute value
+    )*
+    >
+
+    https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch09s04.html
+    """
+    r = """</?(?!(?:{})\\b)[a-z](?:[^>"']|"[^"]*"|'[^']*')*>""".format("|".join(tags_supported))
+    txt = re.sub(
+        pattern=r,
+        repl="",
+        string=txt)
+
+    #   &   &amp;
+    txt = txt.replace("&", "&amp;")
+
+    #   <   &lt;
+    txt = re.sub(
+        pattern=r"<(?!(?:[a-z]+|\/[a-z]+)\b)",
+        repl="&lt;",
+        string=txt,
+    )
+
+    #   >   $gt;
+    # Seems to go through well
+
+    return txt


### PR DESCRIPTION
Please test with a Notification made on `ToDo` doctype and make use of its `description` field to test various html formatting options. Do note that Telegram supports only a handful of HTML Tags and throws when any non-supported tags are sent.