### PR TITLE
feat: add File doctype support to `send_file`

### DIFF
--- a/frappe_telegram/client.py
+++ b/frappe_telegram/client.py
@@ -47,7 +47,7 @@ def send_message(message_text: str, parse_mode=None, user=None, telegram_user=No
     message = bot.send_message(telegram_user_id, text=message_text, parse_mode=parse_mode)
     log_outgoing_message(telegram_bot=from_bot, result=message)
 
-
+@frappe.whitelist()
 def send_file(file, filename=None, message=None, user=None, telegram_user=None, from_bot=None):
     """
     Send a file to the bot
@@ -75,6 +75,25 @@ def send_file(file, filename=None, message=None, user=None, telegram_user=None, 
         else:
             frappe.throw(frappe._("File specified in the File doc does not exist."),
                          exc=FileNotFoundError)
+    elif isinstance(file, str) and "/files/" in file:
+
+        # If file is string, check that the url is internal
+
+        files = frappe.get_all(
+            "File",
+            filters=[["file_url", "=", file]]
+        )
+
+        if files:
+            file_path = frappe.get_site_path(
+                (("" if "/private/" in file else "/public") + file).strip("/"))
+
+            if os.path.exists(file_path):
+                file = open(file_path, 'rb')
+            else:
+                frappe.throw(frappe._("File specified in the file_url does not exist."),
+                             exc=FileNotFoundError)
+
 
     bot = get_bot(from_bot)
     result = bot.send_document(telegram_user_id, document=file, filename=filename, caption=message)

--- a/frappe_telegram/client.py
+++ b/frappe_telegram/client.py
@@ -52,8 +52,9 @@ def send_file(file, filename=None, message=None, user=None, telegram_user=None, 
     """
     Send a file to the bot
 
-    file: (`str` | `filelike object` | `bytes` | `pathlib.Path` | `telegram.Document` | `File Doc`)
-        The file can be either a file_id, a URL, a File doc or a file from disk
+    file: (`str` | `filelike object` | `bytes` | `pathlib.Path` | `telegram.Document` | `frappe.File`)
+        The file can be an internal file path, a telegram file_id, a URL, a File doc or a file from disk.
+            internal file path examples: "/files/example.png", "/private/files/example.png"
     filename: `str`
         Specify custom file name
     message: `str`


### PR DESCRIPTION
This PR adds support for sending files through `send_file` by simply providing a File doc or internal file path.