### PR TITLE
fix: multiple versions

### DIFF
--- a/frappe_telegram/frappe_telegram/doctype/telegram_message/telegram_message.py
+++ b/frappe_telegram/frappe_telegram/doctype/telegram_message/telegram_message.py
@@ -29,4 +29,4 @@ class TelegramMessage(Document):
         chat = frappe.get_doc("Telegram Chat", self.chat)
         chat.last_message_on = self.creation
         chat.last_message_content = self.content
-        chat.save(ignore_permissions=True)
+        chat.save(ignore_permissions=True, ignore_version=True)


### PR DESCRIPTION
when saving all messages also appear in the timeline. Because of this record (last message seen) the whole conversation is also visible in track_versioning. 
![afbeelding](https://github.com/leam-tech/frappe_telegram/assets/48353029/3bce2afc-355a-4cdf-8cca-2b1da4247364)
This is disproportionate becasue all that info is already stored in Telegram Chat Message and is now duplicated 4 times (original message doc, Telegrm Chat last seen, version with new change and version with old change). this much redundancy is not needed.