### PR TITLE
fix: error on Poll return

### DIFF
--- a/frappe_telegram/handlers/logging.py
+++ b/frappe_telegram/handlers/logging.py
@@ -18,7 +18,7 @@ def log_outgoing_message(telegram_bot: str, result: Union[bool, Message]):
     if not isinstance(result, Message):
         return
 
-    if result.text:
+    if len(result.text):
         content = result.text
     elif result.document:
         content = "Sent file: " + result.document.file_name


### PR DESCRIPTION
an Poll has no result.text but it wil be a messageClass. therefore content=None wil return from content=result.text

questioning the length ( > 0) will lead to a skip in this case in which content="" wil return 